### PR TITLE
feat: Add block category and properties for Chest

### DIFF
--- a/assets/prefabs/furnishings/chest.prefab
+++ b/assets/prefabs/furnishings/chest.prefab
@@ -61,5 +61,8 @@
         "screen": "inventory:containerScreen"
     },
     "Network": {
-    }
+    },
+    "categories": ["wood"],
+    "hardness": 8,
+    "mass": 40
 }


### PR DESCRIPTION
Increases the "health" of a chest block from three to eight health points. As well, adds a speed benefit when being mined with an axe.