### PR TITLE
chore: add door assets from `HjerlHede`

### DIFF
--- a/assets/blocks/furnishings/door-bar-bottom.block
+++ b/assets/blocks/furnishings/door-bar-bottom.block
@@ -1,0 +1,6 @@
+{
+  "parent": "CoreAdvancedAssets:DoorBottom",
+  "shape": "CoreAssets:door",
+  "translucent": true,
+  "shadowCasting": false
+}

--- a/assets/blocks/furnishings/door-bar-top.block
+++ b/assets/blocks/furnishings/door-bar-top.block
@@ -1,0 +1,6 @@
+{
+  "parent": "CoreAdvancedAssets:DoorTop",
+  "shape": "CoreAssets:door",
+  "translucent": true,
+  "shadowCasting": false
+}

--- a/assets/blocks/furnishings/door-cyan-bottom.block
+++ b/assets/blocks/furnishings/door-cyan-bottom.block
@@ -1,0 +1,4 @@
+{
+  "parent": "CoreAdvancedAssets:DoorBottom",
+  "shape": "CoreAssets:door"
+}

--- a/assets/blocks/furnishings/door-cyan-top.block
+++ b/assets/blocks/furnishings/door-cyan-top.block
@@ -1,0 +1,4 @@
+{
+  "parent": "CoreAdvancedAssets:DoorTop",
+  "shape": "CoreAssets:door"
+}

--- a/assets/prefabs/furnishings/door-bar-region.prefab
+++ b/assets/prefabs/furnishings/door-bar-region.prefab
@@ -21,7 +21,7 @@
     ]
   },
   "ActAsBlock": {
-    "block": "CoreAssets:door-bar-top"
+    "block": "CoreAdvancedAssets:door-bar-top"
   },
   "Network": {}
 }

--- a/assets/prefabs/furnishings/door-bar-region.prefab
+++ b/assets/prefabs/furnishings/door-bar-region.prefab
@@ -1,0 +1,27 @@
+{
+  "DisplayName": {
+    "name": "Bar Door"
+  },
+  "Door": {
+    "topBlockFamily": "HjerlHede:door-bar-top",
+    "bottomBlockFamily": "HjerlHede:door-bar-bottom",
+    "openSound": "CoreAssets:DoorOpen",
+    "closeSound": "CoreAssets:DoorClose"
+  },
+  "Health": {
+    "currentHealth": 5,
+    "maxHealth": 5,
+    "regenRate": 1,
+    "waitBeforeRegen": 2,
+    "destroyEntityOnNoHealth": true
+  },
+  "DropGrammar": {
+    "itemDrops": [
+      "HjerlHede:door-bar"
+    ]
+  },
+  "ActAsBlock": {
+    "block": "HjerlHede:door-bar-top"
+  },
+  "Network": {}
+}

--- a/assets/prefabs/furnishings/door-bar-region.prefab
+++ b/assets/prefabs/furnishings/door-bar-region.prefab
@@ -3,8 +3,8 @@
     "name": "Bar Door"
   },
   "Door": {
-    "topBlockFamily": "HjerlHede:door-bar-top",
-    "bottomBlockFamily": "HjerlHede:door-bar-bottom",
+    "topBlockFamily": "CoreAssets:door-bar-top",
+    "bottomBlockFamily": "CoreAssets:door-bar-bottom",
     "openSound": "CoreAssets:DoorOpen",
     "closeSound": "CoreAssets:DoorClose"
   },
@@ -17,11 +17,11 @@
   },
   "DropGrammar": {
     "itemDrops": [
-      "HjerlHede:door-bar"
+      "CoreAdvancedAssets:door-bar"
     ]
   },
   "ActAsBlock": {
-    "block": "HjerlHede:door-bar-top"
+    "block": "CoreAssets:door-bar-top"
   },
   "Network": {}
 }

--- a/assets/prefabs/furnishings/door-bar.prefab
+++ b/assets/prefabs/furnishings/door-bar.prefab
@@ -27,6 +27,6 @@
     "itemDrops": ["CoreAdvancedAssets:door-bar"]
   },
   "ActAsBlock": {
-    "block": "CoreAssets:door-bar-top"
+    "block": "CoreAdvancedAssets:door-bar-top"
   }
 }

--- a/assets/prefabs/furnishings/door-bar.prefab
+++ b/assets/prefabs/furnishings/door-bar.prefab
@@ -5,16 +5,16 @@
   },
   "Item": {
     "icon": "engine:items#door",
-    "stackId": "HjerlHede:door-bar",
+    "stackId": "CoreAdvancedAssets:door-bar",
     "consumedOnUse": true,
     "usage": "ON_BLOCK"
   },
   "Door": {
-    "topBlockFamily": "HjerlHede:door-bar-top",
-    "bottomBlockFamily": "HjerlHede:door-bar-bottom",
+    "topBlockFamily": "CoreAssets:door-bar-top",
+    "bottomBlockFamily": "CoreAssets:door-bar-bottom",
     "openSound": "CoreAssets:DoorOpen",
     "closeSound": "CoreAssets:DoorClose",
-    "doorRegionPrefab": "HjerlHede:door-bar-region"
+    "doorRegionPrefab": "CoreAdvancedAssets:door-bar-region"
   },
   "Health": {
     "currentHealth": 5,
@@ -24,9 +24,9 @@
     "destroyEntityOnNoHealth": true
   },
   "DropGrammar": {
-    "itemDrops": ["HjerlHede:door-bar"]
+    "itemDrops": ["CoreAdvancedAssets:door-bar"]
   },
   "ActAsBlock": {
-    "block": "HjerlHede:door-bar-top"
+    "block": "CoreAssets:door-bar-top"
   }
 }

--- a/assets/prefabs/furnishings/door-bar.prefab
+++ b/assets/prefabs/furnishings/door-bar.prefab
@@ -1,0 +1,32 @@
+{
+  "parent": "engine:iconItem",
+  "DisplayName": {
+    "name": "Bar Door"
+  },
+  "Item": {
+    "icon": "engine:items#door",
+    "stackId": "HjerlHede:door-bar",
+    "consumedOnUse": true,
+    "usage": "ON_BLOCK"
+  },
+  "Door": {
+    "topBlockFamily": "HjerlHede:door-bar-top",
+    "bottomBlockFamily": "HjerlHede:door-bar-bottom",
+    "openSound": "CoreAssets:DoorOpen",
+    "closeSound": "CoreAssets:DoorClose",
+    "doorRegionPrefab": "HjerlHede:door-bar-region"
+  },
+  "Health": {
+    "currentHealth": 5,
+    "maxHealth": 5,
+    "regenRate": 1,
+    "waitBeforeRegen": 2,
+    "destroyEntityOnNoHealth": true
+  },
+  "DropGrammar": {
+    "itemDrops": ["HjerlHede:door-bar"]
+  },
+  "ActAsBlock": {
+    "block": "HjerlHede:door-bar-top"
+  }
+}

--- a/assets/prefabs/furnishings/door-cyan-region.prefab
+++ b/assets/prefabs/furnishings/door-cyan-region.prefab
@@ -3,8 +3,8 @@
     "name": "Cyan Door"
   },
   "Door": {
-    "topBlockFamily": "HjerlHede:door-cyan-top",
-    "bottomBlockFamily": "HjerlHede:door-cyan-bottom",
+    "topBlockFamily": "CoreAssets:door-cyan-top",
+    "bottomBlockFamily": "CoreAssets:door-cyan-bottom",
     "openSound": "CoreAssets:DoorOpen",
     "closeSound": "CoreAssets:DoorClose"
   },
@@ -17,11 +17,11 @@
   },
   "DropGrammar": {
     "itemDrops": [
-      "HjerlHede:door-cyan"
+      "CoreAdvancedAssets:door-cyan"
     ]
   },
   "ActAsBlock": {
-    "block": "HjerlHede:door-cyan-top"
+    "block": "CoreAssets:door-cyan-top"
   },
   "Network": {}
 }

--- a/assets/prefabs/furnishings/door-cyan-region.prefab
+++ b/assets/prefabs/furnishings/door-cyan-region.prefab
@@ -21,7 +21,7 @@
     ]
   },
   "ActAsBlock": {
-    "block": "CoreAssets:door-cyan-top"
+    "block": "CoreAdvancedAssets:door-cyan-top"
   },
   "Network": {}
 }

--- a/assets/prefabs/furnishings/door-cyan-region.prefab
+++ b/assets/prefabs/furnishings/door-cyan-region.prefab
@@ -1,0 +1,27 @@
+{
+  "DisplayName": {
+    "name": "Cyan Door"
+  },
+  "Door": {
+    "topBlockFamily": "HjerlHede:door-cyan-top",
+    "bottomBlockFamily": "HjerlHede:door-cyan-bottom",
+    "openSound": "CoreAssets:DoorOpen",
+    "closeSound": "CoreAssets:DoorClose"
+  },
+  "Health": {
+    "currentHealth": 5,
+    "maxHealth": 5,
+    "regenRate": 1,
+    "waitBeforeRegen": 2,
+    "destroyEntityOnNoHealth": true
+  },
+  "DropGrammar": {
+    "itemDrops": [
+      "HjerlHede:door-cyan"
+    ]
+  },
+  "ActAsBlock": {
+    "block": "HjerlHede:door-cyan-top"
+  },
+  "Network": {}
+}

--- a/assets/prefabs/furnishings/door-cyan.prefab
+++ b/assets/prefabs/furnishings/door-cyan.prefab
@@ -27,6 +27,6 @@
     "itemDrops": ["CoreAdvancedAssets:door-cyan"]
   },
   "ActAsBlock": {
-    "block": "CoreAssets:door-cyan-top"
+    "block": "CoreAdvancedAssets:door-cyan-top"
   }
 }

--- a/assets/prefabs/furnishings/door-cyan.prefab
+++ b/assets/prefabs/furnishings/door-cyan.prefab
@@ -1,0 +1,32 @@
+{
+  "parent": "engine:iconItem",
+  "DisplayName": {
+    "name": "Cyan Door"
+  },
+  "Item": {
+    "icon": "engine:items#door",
+    "stackId": "door-cyan",
+    "consumedOnUse": true,
+    "usage": "ON_BLOCK"
+  },
+  "Door": {
+    "topBlockFamily": "HjerlHede:door-cyan-top",
+    "bottomBlockFamily": "HjerlHede:door-cyan-bottom",
+    "openSound": "CoreAssets:DoorOpen",
+    "closeSound": "CoreAssets:DoorClose",
+    "doorRegionPrefab": "HjerlHede:door-cyan-region"
+  },
+  "Health": {
+    "currentHealth": 5,
+    "maxHealth": 5,
+    "regenRate": 1,
+    "waitBeforeRegen": 2,
+    "destroyEntityOnNoHealth": true
+  },
+  "DropGrammar": {
+    "itemDrops": ["HjerlHede:door-cyan"]
+  },
+  "ActAsBlock": {
+    "block": "HjerlHede:door-cyan-top"
+  }
+}

--- a/assets/prefabs/furnishings/door-cyan.prefab
+++ b/assets/prefabs/furnishings/door-cyan.prefab
@@ -10,11 +10,11 @@
     "usage": "ON_BLOCK"
   },
   "Door": {
-    "topBlockFamily": "HjerlHede:door-cyan-top",
-    "bottomBlockFamily": "HjerlHede:door-cyan-bottom",
+    "topBlockFamily": "CoreAssets:door-cyan-top",
+    "bottomBlockFamily": "CoreAssets:door-cyan-bottom",
     "openSound": "CoreAssets:DoorOpen",
     "closeSound": "CoreAssets:DoorClose",
-    "doorRegionPrefab": "HjerlHede:door-cyan-region"
+    "doorRegionPrefab": "CoreAdvancedAssets:door-cyan-region"
   },
   "Health": {
     "currentHealth": 5,
@@ -24,9 +24,9 @@
     "destroyEntityOnNoHealth": true
   },
   "DropGrammar": {
-    "itemDrops": ["HjerlHede:door-cyan"]
+    "itemDrops": ["CoreAdvancedAssets:door-cyan"]
   },
   "ActAsBlock": {
-    "block": "HjerlHede:door-cyan-top"
+    "block": "CoreAssets:door-cyan-top"
   }
 }

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "CoreAdvancedAssets",
-    "version" : "1.220",
+    "version" : "1.2.0",
     "isReleaseManaged": true,
     "author" : "The Terasology Foundation",
     "displayName" : "CoreAdvancedAssets",

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "CoreAdvancedAssets",
-    "version" : "1.1.0",
+    "version" : "1.220",
     "isReleaseManaged": true,
     "author" : "The Terasology Foundation",
     "displayName" : "CoreAdvancedAssets",


### PR DESCRIPTION
- the building resources should reside in a "more accessible" module
- thus they can be used in buildings outside of `HjerlHede` too without requiring to enable `HjerlHede`