### PR TITLE
chore: add display name to chest prefab

### DIFF
--- a/assets/i18n/game.lang
+++ b/assets/i18n/game.lang
@@ -1,0 +1,3 @@
+{
+  "furnishings-chest": "Chest"
+}

--- a/assets/i18n/game_de.lang
+++ b/assets/i18n/game_de.lang
@@ -1,0 +1,3 @@
+{
+  "furnishings-chest": "Kiste"
+}

--- a/assets/i18n/game_en.lang
+++ b/assets/i18n/game_en.lang
@@ -1,0 +1,3 @@
+{
+  "furnishings-chest": "Chest"
+}

--- a/assets/prefabs/furnishings/chest.prefab
+++ b/assets/prefabs/furnishings/chest.prefab
@@ -1,4 +1,7 @@
 {
+    "DisplayName": {
+        "name": "Chest"
+    },
     "InventoryAccess": {
         "input": {
             "top": "0..29",

--- a/assets/prefabs/furnishings/chest.prefab
+++ b/assets/prefabs/furnishings/chest.prefab
@@ -1,6 +1,6 @@
 {
     "DisplayName": {
-        "name": "Chest"
+        "name": "${coreadvancedassets:game#furnishings-chest}"
     },
     "InventoryAccess": {
         "input": {


### PR DESCRIPTION
Minor adjustment to add a display name for chests.
Especially the feature added in https://github.com/Terasology/Inventory/pull/45 will benefit of this.